### PR TITLE
28_Thymeleafを使ったPOST処理

### DIFF
--- a/src/main/java/student/management/StudentManagement/controller/StudentController.java
+++ b/src/main/java/student/management/StudentManagement/controller/StudentController.java
@@ -48,7 +48,7 @@ public class StudentController {
   @GetMapping("/newStudent")
   public String newStudent(Model model) {
     StudentDetail studentDetail = new StudentDetail();
-    studentDetail.setStudentCourses((List.of((new StudentCourse()))));
+    studentDetail.setStudentCourses(List.of(new StudentCourse()));
     model.addAttribute("studentDetail", studentDetail);
     return "registerStudent";
   }

--- a/src/main/java/student/management/StudentManagement/controller/StudentController.java
+++ b/src/main/java/student/management/StudentManagement/controller/StudentController.java
@@ -1,5 +1,6 @@
 package student.management.StudentManagement.controller;
 
+import java.util.Arrays;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -46,7 +47,9 @@ public class StudentController {
 
   @GetMapping("/newStudent")
   public String newStudent(Model model) {
-    model.addAttribute("studentDetail", new StudentDetail());
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudentCourses((List.of((new StudentCourse()))));
+    model.addAttribute("studentDetail", studentDetail);
     return "registerStudent";
   }
 
@@ -57,7 +60,6 @@ public class StudentController {
     }
 
     service.registerStudent(studentDetail);
-
     return "redirect:/studentsList";
   }
 

--- a/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
@@ -3,6 +3,7 @@ package student.management.StudentManagement.repository;
 import java.util.List;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 import student.management.StudentManagement.data.Student;
 import student.management.StudentManagement.data.StudentCourse;
@@ -20,5 +21,11 @@ public interface StudentRepository {
       "INSERT students(id, name, furigana, nickname, mail, area, age, gender, remark, is_deleted)"
           + "VALUES(#{id}, #{name}, #{furigana}, #{nickname}, #{mail}, #{area}, #{age}, #{gender}, #{remark}, false)")
   void insert(Student student);
+
+  @Insert(
+      "INSERT students_courses(student_id, course_name, start_at, end_at)"
+          + "VALUES(#{studentId}, #{courseName}, #{startAt}, #{endAt})")
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void insertCourse(StudentCourse studentCourse);
 
 }

--- a/src/main/java/student/management/StudentManagement/service/StudentService.java
+++ b/src/main/java/student/management/StudentManagement/service/StudentService.java
@@ -1,5 +1,6 @@
 package student.management.StudentManagement.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,11 @@ public class StudentService {
 
   public void registerStudent(StudentDetail studentDetail) {
     repository.insert(studentDetail.getStudent());
+    for (StudentCourse studentCourse : studentDetail.getStudentCourses()) {
+      studentCourse.setStudentId(studentDetail.getStudent().getId());
+      studentCourse.setStartAt(LocalDateTime.now());
+      studentCourse.setEndAt(LocalDateTime.now().plusMonths(2));
+      repository.insertCourse(studentCourse);
+    }
   }
-
 }

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -16,32 +16,36 @@
     <input type="text" id="name" th:field="*{student.name}" required/>
   </div>
   <div>
-    <label for="name">ふりがな：</label>
+    <label for="furigana">ふりがな：</label>
     <input type="text" id="furigana" th:field="*{student.furigana}" required/>
   </div>
   <div>
-    <label for="name">ニックネーム：</label>
-    <input type="text" id="nickname" th:field="*{student.nickname}" required/>
+    <label for="nickname">ニックネーム：</label>
+    <input type="text" id="nickname" th:field="*{student.nickname}"/>
   </div>
   <div>
-    <label for="name">メールアドレス：</label>
+    <label for="mail">メールアドレス：</label>
     <input type="text" id="mail" th:field="*{student.mail}" required/>
   </div>
   <div>
-    <label for="name">地域：</label>
-    <input type="text" id="area" th:field="*{student.area}" required/>
+    <label for="area">地域：</label>
+    <input type="text" id="area" th:field="*{student.area}"/>
   </div>
   <div>
-    <label for="name">年齢：</label>
+    <label for="age">年齢：</label>
     <input type="text" id="age" th:field="*{student.age}" required/>
   </div>
   <div>
-    <label for="name">性別：</label>
-    <input type="text" id="gender" th:field="*{student.gender}" required/>
+    <label for="gender">性別：</label>
+    <input type="text" id="gender" th:field="*{student.gender}"/>
   </div>
   <div>
-    <label for="name">備考：</label>
-    <input type="text" id="remark" th:field="*{student.remark}" required/>
+    <label for="remark">備考：</label>
+    <input type="text" id="remark" th:field="*{student.remark}"/>
+  </div>
+  <div th:each="course, stat : *{studentCourses}">
+    <label for="course">受講コース名：</label>
+    <input type="text" id="course" th:field="*{studentCourses[__${stat.index}__].courseName}"/>
   </div>
   <div>
     <button type="submit">登録</button>

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -44,8 +44,9 @@
     <input type="text" id="remark" th:field="*{student.remark}"/>
   </div>
   <div th:each="course, stat : *{studentCourses}">
-    <label for="course">受講コース名：</label>
-    <input type="text" id="course" th:field="*{studentCourses[__${stat.index}__].courseName}"/>
+    <label for="course" th:for="studentCourse.__${stat.index}__.courseName">受講コース名：</label>
+    <input type="text" id="course" th:id="studentCourse.__${stat.index}__.courseName"
+           th:field="*{studentCourses[__${stat.index}__].courseName}"/>
   </div>
   <div>
     <button type="submit">登録</button>


### PR DESCRIPTION
講座29の動画を参考に新規受講生登録を行う際に、コース情報も一緒に登録できる処理の追加を行いました。
確認をお願いします。

# 課題
### 新規受講生登録を行う際に、コース情報も一緒に登録できるようにする。

## 実施内容
- htmlファイルにコース情報の入力欄を追加する。
- 登録ボタンを押したときに、コース情報がstudents_coursesテーブルに保存されるように処理を追加する。

## 実施結果
htmlファイルにコース情報の入力欄を追加したページ  
![スクリーンショット (186)](https://github.com/user-attachments/assets/cfa32f84-39d5-469b-b3cf-aaa894edcae6)
<br>
新規受講生登録時にコース情報も一緒に登録した結果
![スクリーンショット (183)](https://github.com/user-attachments/assets/b1126502-d129-4616-9465-1bbbf365d9bf)  
<br>
![スクリーンショット (185)](https://github.com/user-attachments/assets/0ba56c06-fdf3-4a11-8b07-7a4decb44747)  
