### PR TITLE
29_受講生情報登録処理の実装

### DIFF
--- a/src/main/java/student/management/StudentManagement/controller/StudentController.java
+++ b/src/main/java/student/management/StudentManagement/controller/StudentController.java
@@ -1,6 +1,5 @@
 package student.management.StudentManagement.controller;
 
-import java.util.Arrays;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -8,6 +7,7 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import student.management.StudentManagement.controller.converter.StudentConverter;
 import student.management.StudentManagement.data.Student;
@@ -60,6 +60,23 @@ public class StudentController {
     }
 
     service.registerStudent(studentDetail);
+    return "redirect:/studentsList";
+  }
+
+  @GetMapping("/student/{id}")
+  public String getStudent(@PathVariable String id, Model model) {
+    StudentDetail studentDetail = service.searchStudent(id);
+    model.addAttribute("studentDetail", studentDetail);
+    return "updateStudent";
+  }
+
+  @PostMapping("/updateStudent")
+  public String updateStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      return "updateStudent";
+    }
+
+    service.updateStudent(studentDetail);
     return "redirect:/studentsList";
   }
 

--- a/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import student.management.StudentManagement.data.Student;
 import student.management.StudentManagement.data.StudentCourse;
 
@@ -14,8 +15,14 @@ public interface StudentRepository {
   @Select("SELECT * FROM students")
   List<Student> search();
 
+  @Select("SELECT * FROM students WHERE id=#{id}")
+  Student searchStudent(String id);
+
   @Select("SELECT * FROM students_courses")
   List<StudentCourse> searchStudentCourses();
+
+  @Select("SELECT * FROM students_courses WHERE student_id=#{studentId}")
+  List<StudentCourse> searchStudentCourse(String studentId);
 
   @Insert(
       "INSERT students(id, name, furigana, nickname, mail, area, age, gender, remark, is_deleted)"
@@ -27,5 +34,16 @@ public interface StudentRepository {
           + "VALUES(#{studentId}, #{courseName}, #{startAt}, #{endAt})")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void insertCourse(StudentCourse studentCourse);
+
+  @Update(
+      "UPDATE students SET name=#{name}, furigana=#{furigana}, nickname=#{nickname}, mail=#{mail}, "
+          + "area=#{area}, age=#{age}, gender=#{gender}, remark=#{remark} "
+          + "WHERE id = #{id}")
+  void updateStudent(Student student);
+
+  @Update(
+      "UPDATE students_courses SET course_name=#{courseName} WHERE id = #{id}")
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void updateStudentCourse(StudentCourse studentCourse);
 
 }

--- a/src/main/java/student/management/StudentManagement/service/StudentService.java
+++ b/src/main/java/student/management/StudentManagement/service/StudentService.java
@@ -23,6 +23,15 @@ public class StudentService {
     return repository.search();
   }
 
+  public StudentDetail searchStudent(String id) {
+    Student student = repository.searchStudent(id);
+    List<StudentCourse> studentCourses = repository.searchStudentCourse(student.getId());
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+    studentDetail.setStudentCourses(studentCourses);
+    return studentDetail;
+  }
+
   public List<StudentCourse> searchStudentCourseList() {
     return repository.searchStudentCourses();
   }
@@ -34,6 +43,13 @@ public class StudentService {
       studentCourse.setStartAt(LocalDateTime.now());
       studentCourse.setEndAt(LocalDateTime.now().plusMonths(2));
       repository.insertCourse(studentCourse);
+    }
+  }
+
+  public void updateStudent(StudentDetail studentDetail) {
+    repository.updateStudent(studentDetail.getStudent());
+    for (StudentCourse studentCourse : studentDetail.getStudentCourses()) {
+      repository.updateStudentCourse(studentCourse);
     }
   }
 }

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -23,7 +23,10 @@
   <tbody>
   <tr th:each="studentDetail : ${studentList}">
     <td th:text="${studentDetail.student.id}">1</td>
-    <td th:text="${studentDetail.student.name}">山田 太郎</td>
+    <td>
+      <a href="/studentList" th:href="@{/student/{id}(id=${studentDetail.student.id})}"
+         th:text="${studentDetail.student.name}">山田 太郎</a>
+    </td>
     <td th:text="${studentDetail.student.furigana}">やまだ たろう</td>
     <td th:text="${studentDetail.student.nickname}">タロー</td>
     <td th:text="${studentDetail.student.mail}">taro.yamada@example.com</td>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生更新</title>
+</head>
+<body>
+<h1>受講生更新</h1>
+<form th:action="@{/updateStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="id">ID：</label>
+    <input type="text" id="id" th:field="*{student.id}" th:readonly="${true}"/>
+  </div>
+  <div>
+    <label for="name">名前：</label>
+    <input type="text" id="name" th:field="*{student.name}" required/>
+  </div>
+  <div>
+    <label for="furigana">ふりがな：</label>
+    <input type="text" id="furigana" th:field="*{student.furigana}" required/>
+  </div>
+  <div>
+    <label for="nickname">ニックネーム：</label>
+    <input type="text" id="nickname" th:field="*{student.nickname}"/>
+  </div>
+  <div>
+    <label for="mail">メールアドレス：</label>
+    <input type="text" id="mail" th:field="*{student.mail}" required/>
+  </div>
+  <div>
+    <label for="area">地域：</label>
+    <input type="text" id="area" th:field="*{student.area}"/>
+  </div>
+  <div>
+    <label for="age">年齢：</label>
+    <input type="text" id="age" th:field="*{student.age}" required/>
+  </div>
+  <div>
+    <label for="gender">性別：</label>
+    <input type="text" id="gender" th:field="*{student.gender}"/>
+  </div>
+  <div>
+    <label for="remark">備考：</label>
+    <input type="text" id="remark" th:field="*{student.remark}"/>
+  </div>
+  <div th:each="course, stat : *{studentCourses}">
+    <label for="courseId" th:for="studentCourse.__${stat.index}__.id">受講コースID：</label>
+    <input type="text" id="courseId" th:id="studentCourse.__${stat.index}__.id"
+           th:field="*{studentCourses[__${stat.index}__].id}"/>
+    <label for="course" th:for="studentCourse.__${stat.index}__.courseName">受講コース名：</label>
+    <input type="text" id="course" th:id="studentCourse.__${stat.index}__.courseName"
+           th:field="*{studentCourses[__${stat.index}__].courseName}"/>
+  </div>
+  <div>
+    <button type="submit">更新</button>
+  </div>
+</form>
+</body>
+</html>


### PR DESCRIPTION
講座30の動画を参考に受講生情報の更新処理の追加を行いました。確認をお願いします。

# 課題
### 受講生情報の更新できる処理を追加する。

## 実施内容
- service,controller,repositoryに受講生情報を更新する処理を追加した。
- 受講生一覧の名前欄に、更新ページに飛ぶリンクを設定した。
- 受講生情報を更新するためのページを作成した。

## 実施結果
更新前のテーブル  
![スクリーンショット (188)](https://github.com/user-attachments/assets/a5eff854-fa0d-4e13-adb7-475cc135c778)  
![スクリーンショット (189)](https://github.com/user-attachments/assets/7543a021-4413-4829-9bed-c66591e07cb5)  
<br>
更新後のテーブル(赤線部分を更新)  
![スクリーンショット (190)](https://github.com/user-attachments/assets/82e65ec1-86b7-45ae-81de-cb776822ac37)  
![スクリーンショット (191)](https://github.com/user-attachments/assets/678c4e8a-b4cd-410f-8878-d9cf3d7d6aaa)  
![スクリーンショット (192)](https://github.com/user-attachments/assets/ce6b7dcc-890b-419b-8f8f-1bc6a94d9a9d)  
