### PR TITLE
30_受講生情報更新処理の実装

### DIFF
--- a/src/main/java/student/management/StudentManagement/controller/StudentController.java
+++ b/src/main/java/student/management/StudentManagement/controller/StudentController.java
@@ -27,6 +27,15 @@ public class StudentController {
     this.converter = converter;
   }
 
+  @GetMapping("/allStudentsList")
+  public String getAllStudentList(Model model) {
+    List<Student> students = service.searchAllStudentList();
+    List<StudentCourse> studentCourses = service.searchStudentCourseList();
+
+    model.addAttribute("studentList", converter.convertStudentDetails(students, studentCourses));
+    return "studentList";
+  }
+
   @GetMapping("/studentsList")
   public String getStudentList(Model model) {
     List<Student> students = service.searchStudentList();

--- a/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
@@ -37,7 +37,7 @@ public interface StudentRepository {
 
   @Update(
       "UPDATE students SET name=#{name}, furigana=#{furigana}, nickname=#{nickname}, mail=#{mail}, "
-          + "area=#{area}, age=#{age}, gender=#{gender}, remark=#{remark} "
+          + "area=#{area}, age=#{age}, gender=#{gender}, remark=#{remark}, is_deleted=#{isDeleted} "
           + "WHERE id = #{id}")
   void updateStudent(Student student);
 

--- a/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
@@ -13,6 +13,9 @@ import student.management.StudentManagement.data.StudentCourse;
 public interface StudentRepository {
 
   @Select("SELECT * FROM students")
+  List<Student> searchAllStudents();
+
+  @Select("SELECT * FROM students WHERE is_deleted=false")
   List<Student> search();
 
   @Select("SELECT * FROM students WHERE id=#{id}")

--- a/src/main/java/student/management/StudentManagement/service/StudentService.java
+++ b/src/main/java/student/management/StudentManagement/service/StudentService.java
@@ -19,6 +19,10 @@ public class StudentService {
     this.repository = repository;
   }
 
+  public List<Student> searchAllStudentList() {
+    return repository.searchAllStudents();
+  }
+
   public List<Student> searchStudentList() {
     return repository.search();
   }

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -36,7 +36,7 @@
     <td th:text="${studentDetail.student.gender}">男性</td>
     <td th:text="${studentDetail.student.remark}">受け放題</td>
     <td>
-      <input type="checkbox" th:checked="${studentDetail.student.isDeleted}"/>
+      <input type="checkbox" th:checked="${studentDetail.student.isDeleted}" th:disabled="${true}"/>
     </td>
   </tr>
   </tbody>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -18,6 +18,7 @@
     <th>年齢</th>
     <th>性別</th>
     <th>備考</th>
+    <th>キャンセル</th>
   </tr>
   </thead>
   <tbody>
@@ -34,6 +35,9 @@
     <td th:text="${studentDetail.student.age}">20</td>
     <td th:text="${studentDetail.student.gender}">男性</td>
     <td th:text="${studentDetail.student.remark}">受け放題</td>
+    <td>
+      <input type="checkbox" th:checked="${studentDetail.student.isDeleted}"/>
+    </td>
   </tr>
   </tbody>
 </table>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -43,6 +43,10 @@
     <label for="remark">備考：</label>
     <input type="text" id="remark" th:field="*{student.remark}"/>
   </div>
+  <div>
+    <label for="isDeleted">キャンセル：</label>
+    <input type="checkbox" id="isDeleted" th:field="*{student.deleted}"/>
+  </div>
   <div th:each="course, stat : *{studentCourses}">
     <label for="courseId" th:for="studentCourse.__${stat.index}__.id">受講コースID：</label>
     <input type="text" id="courseId" th:id="studentCourse.__${stat.index}__.id"


### PR DESCRIPTION
以下のことを行いました。確認をお願いします。

# 課題
### 受講生情報を論理削除する機能を追加する。

## 実施内容
- 受講生情報の更新画面に論理削除をする欄を追加。
- 論理削除した受講生が一覧画面に表示されないようにする処理を追加。

## 実施結果
全受講生一覧の画面  
![スクリーンショット (193)](https://github.com/user-attachments/assets/3073e1a5-e631-45b4-8548-5a32acbe90d4)  
<br>
論理削除機能を受講生情報更新画面  
![スクリーンショット (197)](https://github.com/user-attachments/assets/02c7f0b8-431c-4c6c-9999-24ae9eb81d18)  
<br>
論理削除が更新された全受講生一覧の画面  
![スクリーンショット (199)](https://github.com/user-attachments/assets/5db1d362-85e5-4772-b819-169564d547ca)  
<br>
論理削除した受講生が表示されないようにした一覧画面  
![スクリーンショット (198)](https://github.com/user-attachments/assets/f278ca26-5a8f-44b4-8fba-c404fd760530)  
